### PR TITLE
Feature/helihhsp 118 expand anchor link blocks

### DIFF
--- a/resources/acf-data/group_62a7201df2c60.json
+++ b/resources/acf-data/group_62a7201df2c60.json
@@ -44,6 +44,27 @@
                             "delay": 0
                         },
                         {
+                          "key": "field_d6c3dd185a59",
+                          "label": "Display in Anchor Navigation",
+                          "name": "show_in_anchor_link",
+                          "aria-label": "",
+                          "type": "true_false",
+                          "instructions": "",
+                          "required": 0,
+                          "conditional_logic": 0,
+                          "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                          },
+                          "message": "Choose whether to display the heading in the anchor link navigation.",
+                          "default_value": 0,
+                          "allow_in_bindings": 0,
+                          "ui_on_text": "",
+                          "ui_off_text": "",
+                          "ui": 1
+                        },
+                        {
                             "key": "field_652e46d569877",
                             "label": "Accordion",
                             "name": "faq_accordion",
@@ -158,6 +179,27 @@
                             "toolbar": "full",
                             "media_upload": 0,
                             "delay": 0
+                        },
+                        {
+                          "key": "field_b8253adbd593",
+                          "label": "Display in Anchor Navigation",
+                          "name": "show_in_anchor_link",
+                          "aria-label": "",
+                          "type": "true_false",
+                          "instructions": "",
+                          "required": 0,
+                          "conditional_logic": 0,
+                          "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                          },
+                          "message": "Choose whether to display the heading in the anchor link navigation. Note, that for WYSIWYG editors, this setting will target H2 headings only.",
+                          "default_value": 0,
+                          "allow_in_bindings": 0,
+                          "ui_on_text": "",
+                          "ui_off_text": "",
+                          "ui": 1
                         },
                         {
                             "key": "field_63ca63fc0f809",
@@ -402,6 +444,27 @@
                             "placeholder": "",
                             "prepend": "",
                             "append": ""
+                        },
+                        {
+                          "key": "field_464c92b49015",
+                          "label": "Display in Anchor Navigation",
+                          "name": "show_in_anchor_link",
+                          "aria-label": "",
+                          "type": "true_false",
+                          "instructions": "",
+                          "required": 0,
+                          "conditional_logic": 0,
+                          "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                          },
+                          "message": "Choose whether to display the heading in the anchor link navigation.",
+                          "default_value": 0,
+                          "allow_in_bindings": 0,
+                          "ui_on_text": "",
+                          "ui_off_text": "",
+                          "ui": 1
                         },
                         {
                             "key": "field_6901b94c052ba",
@@ -1212,6 +1275,27 @@
                             "bidirectional": 0,
                             "ui": 1,
                             "bidirectional_target": []
+                        },
+                        {
+                          "key": "field_d108fd49daca",
+                          "label": "Display in Anchor Navigation",
+                          "name": "show_in_anchor_link",
+                          "aria-label": "",
+                          "type": "true_false",
+                          "instructions": "",
+                          "required": 0,
+                          "conditional_logic": 0,
+                          "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                          },
+                          "message": "Choose whether to display the heading in the anchor link navigation.",
+                          "default_value": 0,
+                          "allow_in_bindings": 0,
+                          "ui_on_text": "",
+                          "ui_off_text": "",
+                          "ui": 1
                         }
                     ],
                     "min": "",
@@ -2042,6 +2126,27 @@
                             "delay": 0
                         },
                         {
+                          "key": "field_63d7e99a216e",
+                          "label": "Display in Anchor Navigation",
+                          "name": "show_in_anchor_link",
+                          "aria-label": "",
+                          "type": "true_false",
+                          "instructions": "",
+                          "required": 0,
+                          "conditional_logic": 0,
+                          "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                          },
+                          "message": "Choose whether to display the heading in the anchor link navigation. Note, that for WYSIWYG editors, this setting will target H2 headings only.",
+                          "default_value": 0,
+                          "allow_in_bindings": 0,
+                          "ui_on_text": "",
+                          "ui_off_text": "",
+                          "ui": 1
+                        },
+                        {
                             "key": "field_62ac787597bb4",
                             "label": "Background color",
                             "name": "background_color",
@@ -2138,6 +2243,27 @@
                                     "media_upload": 0,
                                     "delay": 0,
                                     "parent_repeater": "field_6932690e1fb77"
+                                },
+                                {
+                                  "key": "field_dce6892ddcff",
+                                  "label": "Display in Anchor Navigation",
+                                  "name": "show_in_anchor_link",
+                                  "aria-label": "",
+                                  "type": "true_false",
+                                  "instructions": "",
+                                  "required": 0,
+                                  "conditional_logic": 0,
+                                  "wrapper": {
+                                    "width": "",
+                                    "class": "",
+                                    "id": ""
+                                  },
+                                  "message": "Choose whether to display the heading in the anchor link navigation. Note, that for WYSIWYG editors, this setting will target H2 headings only.",
+                                  "default_value": 0,
+                                  "allow_in_bindings": 0,
+                                  "ui_on_text": "",
+                                  "ui_off_text": "",
+                                  "ui": 1
                                 }
                             ]
                         }
@@ -2493,6 +2619,27 @@
                             "prepend": "",
                             "append": "",
                             "maxlength": ""
+                        },
+                        {
+                          "key": "field_fc8e87897a93",
+                          "label": "Display in Anchor Navigation",
+                          "name": "show_in_anchor_link",
+                          "aria-label": "",
+                          "type": "true_false",
+                          "instructions": "",
+                          "required": 0,
+                          "conditional_logic": 0,
+                          "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                          },
+                          "message": "Choose whether to display the heading in the anchor link navigation.",
+                          "default_value": 0,
+                          "allow_in_bindings": 0,
+                          "ui_on_text": "",
+                          "ui_off_text": "",
+                          "ui": 1
                         },
                         {
                             "key": "field_63ae87670bc27",
@@ -3600,6 +3747,27 @@
                             "toolbar": "full",
                             "media_upload": 1,
                             "delay": 0
+                        },
+                        {
+                          "key": "field_b8ed9b33de90",
+                          "label": "Display in Anchor Navigation",
+                          "name": "show_in_anchor_link",
+                          "aria-label": "",
+                          "type": "true_false",
+                          "instructions": "",
+                          "required": 0,
+                          "conditional_logic": 0,
+                          "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                          },
+                          "message": "Choose whether to display the heading in the anchor link navigation. Note, that for WYSIWYG editors, this setting will target H2 headings only.",
+                          "default_value": 0,
+                          "allow_in_bindings": 0,
+                          "ui_on_text": "",
+                          "ui_off_text": "",
+                          "ui": 1
                         }
                     ],
                     "min": "",
@@ -3631,6 +3799,27 @@
                             "toolbar": "full",
                             "media_upload": 0,
                             "delay": 0
+                        },
+                        {
+                          "key": "field_66cca57fb18e§",
+                          "label": "Display in Anchor Navigation",
+                          "name": "show_in_anchor_link",
+                          "aria-label": "",
+                          "type": "true_false",
+                          "instructions": "",
+                          "required": 0,
+                          "conditional_logic": 0,
+                          "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                          },
+                          "message": "Choose whether to display the heading in the anchor link navigation. Note, that for WYSIWYG editors, this setting will target H2 headings only.",
+                          "default_value": 0,
+                          "allow_in_bindings": 0,
+                          "ui_on_text": "",
+                          "ui_off_text": "",
+                          "ui": 1
                         },
                         {
                             "key": "field_690062a9febcc",

--- a/resources/assets/scripts/routes/common.js
+++ b/resources/assets/scripts/routes/common.js
@@ -168,6 +168,12 @@ export default {
             const ul = document.createElement('ul');
 
           headings.forEach(heading => {
+            // If heading doesn't match a h2 element, we most likely are on a WYSIWYG editor
+            // We can try to fetch the heading from inside the element again
+            if (!heading.matches('h2')) {
+              heading = heading.querySelector('h2');
+            }
+
             const headingText = heading.innerText.trim();
 
             if (!headingText) {

--- a/resources/views/flexible/about_meta.php
+++ b/resources/views/flexible/about_meta.php
@@ -8,7 +8,8 @@ if (have_rows('links')): ?>
         <div class="row">
             <?php if (get_field('links_header')): ?>
             <div class="col-12 pb-5">
-                <h2><?php the_field('links_header'); ?></h2>
+              <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+                <h2 <?= $anchor_link ? 'data-anchor="true"' : '';  ?>><?php the_field('links_header'); ?></h2>
             </div>
             <?php endif; ?>
 

--- a/resources/views/flexible/accordion_with_textarea.php
+++ b/resources/views/flexible/accordion_with_textarea.php
@@ -39,10 +39,12 @@ $accordionContentBgColor = 'background-color: ' . get_sub_field('content_backgro
         ?>
     <?php
     $assignedTags = '';
-
-    foreach (get_sub_field('tags') as $k => $v):
-        $assignedTags .= $v . ',';
-    endforeach;
+    $tags = get_sub_field('tags');
+    if ($tags):
+      foreach (get_sub_field('tags') as $k => $v):
+          $assignedTags .= $v . ',';
+      endforeach;
+    endif;
 
     $LIs .=
         '<li>
@@ -90,7 +92,9 @@ $accordionContentBgColor = 'background-color: ' . get_sub_field('content_backgro
     <?php
     endwhile; ?>
 
-    <div class="accordion-with-description--content" style="<?php echo $accordionContentBgColor; ?>">
+  <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+
+    <div class="accordion-with-description--content" style="<?php echo $accordionContentBgColor; ?>" <?= $anchor_link ? 'data-anchor="true"' : '';  ?>>
         <?php if (get_sub_field('content')):
             the_sub_field('content');
         endif; ?>

--- a/resources/views/flexible/banner.php
+++ b/resources/views/flexible/banner.php
@@ -15,7 +15,8 @@ $cta_background_color_style = "style=\"background-color: {$cta_background_color}
 <div class="banner container-fluid" <?php echo $background_color_style; ?>>
     <div class="text-center ihhce">
         <div class="content">
-            <h2><?php echo $section_title; ?></h2>
+            <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+            <h2 <?= $anchor_link ? 'data-anchor="true"' : '';  ?>><?php echo $section_title; ?></h2>
             <?php if ($body_text) {
                 the_sub_field('body_text');
             } ?>

--- a/resources/views/flexible/contact_block.php
+++ b/resources/views/flexible/contact_block.php
@@ -57,7 +57,8 @@ if (!function_exists('ihh_normalize_time')) {
             <div class="contact-header" <?php if ($head_bg) {
                 echo 'style="background-color: ' . esc_attr($head_bg) . ';"';
             } ?>>
-                <h2 class="contact-heading"><?php echo esc_html(get_the_title($contact_id)); ?></h2>
+                <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+                <h2 class="contact-heading" <?= $anchor_link ? 'data-anchor="true"' : '';  ?>><?php echo esc_html(get_the_title($contact_id)); ?></h2>
             </div>
 
             <div class="contact-content" <?php if ($cont_bg) {

--- a/resources/views/flexible/editor_container.php
+++ b/resources/views/flexible/editor_container.php
@@ -1,8 +1,9 @@
 <?php if( get_sub_field('content') ) : ?>
-<div class="container">
-    <div class="w-100 h-100 my-5 ihhce">
+  <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+  <div class="container">
+      <div class="w-100 h-100 my-5 ihhce" <?= $anchor_link ? 'data-anchor="true"' : '';  ?>>
 
-        <?php the_sub_field('content'); ?>
-    </div>
-</div>
+          <?php the_sub_field('content'); ?>
+      </div>
+  </div>
 <?php endif ?>

--- a/resources/views/flexible/faq.php
+++ b/resources/views/flexible/faq.php
@@ -14,7 +14,8 @@
 <div class="container ihhce" id="faqs">
 
     <?php if (get_sub_field('section_heading')): ?>
-    <div class="accordion-header" id="section-heading-<?php echo get_the_ID(); ?>">
+    <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+    <div class="accordion-header" id="section-heading-<?php echo get_the_ID(); ?>" <?= $anchor_link ? 'data-anchor="true"' : '';  ?>>
         <?php the_sub_field('section_heading'); ?>
     </div>
     <?php endif; ?>

--- a/resources/views/flexible/highlighted_content.php
+++ b/resources/views/flexible/highlighted_content.php
@@ -9,7 +9,8 @@ $bg_style = $bg_norm ? ' style="background-color:' . esc_attr($bg_norm) . ';"' :
 
 <div class="highlighted-content<?php echo esc_attr($bg_class); ?> ihhce">
     <div class="content-wrapper" <?php echo $bg_style; ?>>
-        <div class="text-wrapper">
+      <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+        <div class="text-wrapper" <?= $anchor_link ? 'data-anchor="true"' : '';  ?>>
             <?php the_sub_field('content'); ?>
         </div>
     </div>

--- a/resources/views/flexible/highlighted_content_x2.php
+++ b/resources/views/flexible/highlighted_content_x2.php
@@ -15,7 +15,8 @@
     ?>
 
     <div class="highlighted-content-box<?php echo esc_attr($bg_class); ?>" <?php echo $bg_style; ?>>
-        <div class="content-wrapper">
+      <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+      <div class="content-wrapper" <?= $anchor_link ? 'data-anchor="true"' : '';  ?>>
             <?php the_sub_field('text_content'); ?>
         </div>
     </div>

--- a/resources/views/flexible/video_and_text.php
+++ b/resources/views/flexible/video_and_text.php
@@ -14,7 +14,8 @@ $layout_class = $layout ? 'image-left' : 'image-right';
         <div class="video_and_text <?php echo $layout_class; ?>">
 
             <?php if (!empty($body_text)): ?>
-            <div class="content">
+              <?php $anchor_link = get_sub_field('show_in_anchor_link'); ?>
+            <div class="content" <?= $anchor_link ? 'data-anchor="true"' : '';  ?>>
                 <?php echo apply_filters('the_content', $body_text); ?>
             </div>
             <?php endif; ?>


### PR DESCRIPTION
Added anchor link toggle button for the following blocks:
- Text editor block
- Video and text
- Banner
- Accordion
- Accordion with higlight
- Higlighted content
- Higlighted content x2
- Contact block
- Link images


Also a small change in JS file. Some of these blocks don't have their own individual "title/header" fields, so the title is added inside of the WYSIWYG field. The JS change now takes this into consideration, if the data-attribute is added to something other than an `<h2>` element, we look deeper into the element. In all of the cases, the targeted element in this instance would be a `<div>`, so we check if this element includes a `<h2>`